### PR TITLE
Explicitly depend on newer celestial packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,4 +10,4 @@ License: LGPL-3
 Encoding: UTF-8
 LazyData: true
 Depends: ProSpect (>= 0.2.2), data.table, hdf5r
-Imports: celestial, bit64, foreach, doSNOW, checkmate, snow, ini
+Imports: celestial (>= 1.4.5), bit64, foreach, doSNOW, checkmate, snow, ini


### PR DESCRIPTION
The lack of versioning on the celestial package listing meant that we
were suffering unexpected runtime errors in platforms where celestial
1.4.1 (the latest available in CRAN as of this writing) was installed.