### PR TITLE
More flexible writing of SED objects

### DIFF
--- a/R/genShark.R
+++ b/R/genShark.R
@@ -100,30 +100,6 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
     close(pb)
   }
 
-  outSED=as.data.table(rbind(outSED))
-  colnamesSED=c(
-    paste0('ab_mag_nodust_b_d_',filters),
-    paste0('ab_mag_nodust_b_m_',filters),
-    paste0('ab_mag_nodust_b_',filters),
-    paste0('ab_mag_nodust_d_',filters),
-    paste0('ab_mag_nodust_t_',filters),
-    paste0('ap_mag_nodust_b_d_',filters),
-    paste0('ap_mag_nodust_b_m_',filters),
-    paste0('ap_mag_nodust_b_',filters),
-    paste0('ap_mag_nodust_d_',filters),
-    paste0('ap_mag_nodust_t_',filters),
-    paste0('ab_mag_dust_b_d_',filters),
-    paste0('ab_mag_dust_b_m_',filters),
-    paste0('ab_mag_dust_b_',filters),
-    paste0('ab_mag_dust_d_',filters),
-    paste0('ab_mag_dust_t_',filters),
-    paste0('ap_mag_dust_b_d_',filters),
-    paste0('ap_mag_dust_b_m_',filters),
-    paste0('ap_mag_dust_b_',filters),
-    paste0('ap_mag_dust_d_',filters),
-    paste0('ap_mag_dust_t_',filters)
-    )
-  colnames(outSED)=colnamesSED
   outSED=cbind(id_galaxy=Shark_SFH[['galaxies/id_galaxy']][select], outSED)
 
   Shark_SFH$close()
@@ -134,14 +110,7 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
 
   if (write_final_file) {
     outdir = paste(path_shark, 'Photometry', snapshot, subvolume, sep='/')
-    if (!dir.exists(outdir)) {
-      dir.create(outdir, recursive=TRUE)
-    }
-    outfile = paste(outdir, final_file_output, sep='/')
-    if (verbose) {
-      message(paste('Writing CSV file on ', outfile))
-    }
-    fwrite(outSED, file=outfile)
+    write.SED(outSED, filters, outdir, final_file_output, verbose=TRUE)
   }
 
   class(outSED)=c(class(outSED),'Viperfish-Shark')

--- a/R/genSting.R
+++ b/R/genSting.R
@@ -171,45 +171,12 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
     close(pb)
   }
 
-  outSED=as.data.frame(outSED)
-  colnamesSED=c(
-    'id_galaxy_sky',
-    paste0('ab_mag_nodust_b_d_',filters),
-    paste0('ab_mag_nodust_b_m_',filters),
-    paste0('ab_mag_nodust_b_',filters),
-    paste0('ab_mag_nodust_d_',filters),
-    paste0('ab_mag_nodust_t_',filters),
-    paste0('ap_mag_nodust_b_d_',filters),
-    paste0('ap_mag_nodust_b_m_',filters),
-    paste0('ap_mag_nodust_b_',filters),
-    paste0('ap_mag_nodust_d_',filters),
-    paste0('ap_mag_nodust_t_',filters),
-    paste0('ab_mag_dust_b_d_',filters),
-    paste0('ab_mag_dust_b_m_',filters),
-    paste0('ab_mag_dust_b_',filters),
-    paste0('ab_mag_dust_d_',filters),
-    paste0('ab_mag_dust_t_',filters),
-    paste0('ap_mag_dust_b_d_',filters),
-    paste0('ap_mag_dust_b_m_',filters),
-    paste0('ap_mag_dust_b_',filters),
-    paste0('ap_mag_dust_d_',filters),
-    paste0('ap_mag_dust_t_',filters)
-    )
-  colnames(outSED)=colnamesSED
-  #outSED=cbind(id_galaxy=mockcone$id_galaxy, outSED)
-
-  #output=list(outSED=outSED, SFHfull=SFHfull)
-
   outSED=unique(outSED, by=id_galaxy_sky)
 
   outSED=outSED[match(Sting_id_galaxy_sky, outSED$id_galaxy_sky),]
 
   if (write_final_file) {
-    outfile = paste(dirname(file_sting), final_file_output, sep='/')
-    if (verbose) {
-      message(paste('Writing CSV file on ', outfile))
-    }
-    fwrite(outSED, file=outfile)
+    write.SED(outSED, filters, dirname(file_sting), final_file_output)
   }
 
   if(verbose){

--- a/R/write.dataset.R
+++ b/R/write.dataset.R
@@ -109,6 +109,61 @@ write.SED.hdf5=function(SED, filename='temp.hdf5', overwrite=FALSE, filters=c('F
   write.custom.dataset(filename=filename, group="SED/ap_dust", object=SED[,1+colrun+Ncol*11], dataset.name='total', overwrite=overwrite)
 }
 
+write.SED.csv = function(SED, filters, fname)
+{
+  colnames = c(
+      'id_galaxy',
+      paste0('ab_mag_nodust_b_d_',filters),
+      paste0('ab_mag_nodust_b_m_',filters),
+      paste0('ab_mag_nodust_b_',filters),
+      paste0('ab_mag_nodust_d_',filters),
+      paste0('ab_mag_nodust_t_',filters),
+      paste0('ap_mag_nodust_b_d_',filters),
+      paste0('ap_mag_nodust_b_m_',filters),
+      paste0('ap_mag_nodust_b_',filters),
+      paste0('ap_mag_nodust_d_',filters),
+      paste0('ap_mag_nodust_t_',filters),
+      paste0('ab_mag_dust_b_d_',filters),
+      paste0('ab_mag_dust_b_m_',filters),
+      paste0('ab_mag_dust_b_',filters),
+      paste0('ab_mag_dust_d_',filters),
+      paste0('ab_mag_dust_t_',filters),
+      paste0('ap_mag_dust_b_d_',filters),
+      paste0('ap_mag_dust_b_m_',filters),
+      paste0('ap_mag_dust_b_',filters),
+      paste0('ap_mag_dust_d_',filters),
+      paste0('ap_mag_dust_t_',filters)
+  )
+  colnames(SED) = colnames
+  fwrite(SED, file=fname)
+}
+
+write.SED = function(SED, filters, outdir, fname, verbose=FALSE)
+{
+  # Automatically determine format from file extension
+  if (endsWith(fname, '.hdf5') | endsWith(fname, '.h5')) {
+    format = 'hdf5'
+  }
+  else if (endsWith(fname, '.csv')) {
+    format = 'csv'
+  }
+  else {
+    stop(paste("Cannot determine format (hdf5/csv) from file extension:", fname))
+  }
+
+  if (!dir.exists(outdir)) {
+    dir.create(outdir, recursive=TRUE)
+  }
+  fname = paste(outdir, fname, sep='/')
+  message(paste('Writing SED to', fname))
+  if (format == 'hdf5') {
+    write.SED.hdf5(SED, fname, overwrite=TRUE, filters=filters)
+  }
+  else if (format == 'csv') {
+    write.SED.csv(outSED, filters, fname)
+  }
+}
+
 write.SFH=function(SFHlist, filename='temp.hdf5', overwrite=FALSE){
   assertPathForOutput(filename, overwrite=TRUE)
 

--- a/R/write.dataset.R
+++ b/R/write.dataset.R
@@ -61,7 +61,7 @@ write.custom.dataset = function(filename='temp.hdf5', # hd5 filename
   }
 }
 
-write.SED=function(SED, filename='temp.hdf5', overwrite=FALSE, filters=c('FUV', 'NUV', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1', 'W2', 'W3', 'W4', 'P100', 'P160', 'S250', 'S350', 'S500')){
+write.SED.hdf5=function(SED, filename='temp.hdf5', overwrite=FALSE, filters=c('FUV', 'NUV', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1', 'W2', 'W3', 'W4', 'P100', 'P160', 'S250', 'S350', 'S500')){
 
   assertPathForOutput(filename, overwrite=TRUE)
   file.h5=h5file(filename=filename, mode='a')


### PR DESCRIPTION
These changes allow users to specify whether they want to output the resulting SED objects into a csv or hdf5 file simply by specifying the correct extension in the filename (e.g., `final_file_output="output.hdf5"` or `final_file_output="output.csv"`). Because the decision is made purely by looking at the filename extension, the signature of both `genSting` and `genShark` hasn't changed.

This is something @cdplagos was interested in having, so here it goes.