### PR TITLE
Several fixes

### DIFF
--- a/R/genShark.R
+++ b/R/genShark.R
@@ -100,6 +100,7 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
     close(pb)
   }
 
+  outSED=as.data.table(rbind(outSED))
   outSED=cbind(id_galaxy=Shark_SFH[['galaxies/id_galaxy']][select], outSED)
 
   Shark_SFH$close()

--- a/R/genSting.R
+++ b/R/genSting.R
@@ -111,65 +111,69 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
 
   #SEDlookup=data.table(id=unlist(mocksubsets$idlist), subsnapID=rep(mocksubsets$subsnapID, mocksubsets$Nid))
 
-  cl=makeCluster(cores)
-  registerDoSNOW(cl)
-
   #iterations=dim(mockcone)[1]
   if(restart){
     outSED=fread(temp_file_output)
     subsnapIDs=base::unique(mockcone[!id_galaxy_sky %in% outSED$V1,subsnapID])
+    run_foreach = length(subsnapIDs) > 0
   }else{
     subsnapIDs=base::unique(mockcone$subsnapID)
+    run_foreach = TRUE
   }
 
   mockcone=as.big.matrix(mockcone)
   mockpoint=describe(mockcone)
 
-  if(verbose){
-    pb = txtProgressBar(max = length(subsnapIDs), style = 3)
-    progress = function(n) setTxtProgressBar(pb, n)
-    opts = list(progress=progress)
-  }
+  if (run_foreach) {
 
-  outSED=foreach(i=1:length(subsnapIDs), .combine=.dumpout, .init=temp_file_output, .final=.dumpin, .inorder=FALSE, .options.snow = if(verbose){opts}, .packages=c('Viperfish','bigmemory'))%dopar%{
-  #for(i in 1:length(subsnapIDs)){
-    use=subsnapIDs[i]
-    mockloop=attach.big.matrix(mockpoint)
-    select=which(mockloop[,'subsnapID']==use)
-    snapshot=mockloop[select[1],'snapshot']
-    subvolume=mockloop[select[1],'subvolume']
-    id_galaxy_sky=mockloop[select,'id_galaxy_sky']
-    id_galaxy_sam=mockloop[select,'id_galaxy_sam']
-    zcos=mockloop[select,'zcos']
-    zobs=mockloop[select,'zobs']
-    SFHsing_subsnap=getSFHsing(id_galaxy_sam=id_galaxy_sam, snapshot=snapshot, subvolume=subvolume, path_shark=path_shark)
+    cl=makeCluster(cores)
+    registerDoSNOW(cl)
 
-    SFRbulge_d_subsnap=SFHsing_subsnap$SFRbulge_d
-    SFRbulge_m_subsnap=SFHsing_subsnap$SFRbulge_m
-    SFRdisk_subsnap=SFHsing_subsnap$SFRdisk
-    Zbulge_d_subsnap=SFHsing_subsnap$Zbulge_d
-    Zbulge_m_subsnap=SFHsing_subsnap$Zbulge_m
-    Zdisk_subsnap=SFHsing_subsnap$Zdisk
-
-    # Here we divide by h since the simulations output SFR in their native Msun/yr/h units.
-
-    tempout=foreach(j=1:length(select), .combine='rbind')%do%{
-      tempSED=tryCatch(c(id_galaxy_sky[SFHsing_subsnap$keep[j]], unlist(genSED(SFRbulge_d=SFRbulge_d_subsnap[j,]/h, SFRbulge_m=SFRbulge_m_subsnap[j,]/h, SFRdisk=SFRdisk_subsnap[j,]/h, redshift=zobs[j], time=time[1:dim(SFRdisk_subsnap)[2]]-cosdistTravelTime(zcos[j], ref='planck')*1e9, speclib=BC03lr, Zbulge_d=Zbulge_d_subsnap[j,], Zbulge_m=Zbulge_m_subsnap[j,], Zdisk=Zdisk_subsnap[j,], filtout=filtout, Dale=Dale_Msol, sparse=sparse, tau_birth=tau_birth, tau_screen=tau_screen, intSFR = intSFR))), error = function(e) NULL)
-      tempSED
+    if(verbose){
+      pb = txtProgressBar(max = length(subsnapIDs), style = 3)
+      progress = function(n) setTxtProgressBar(pb, n)
+      opts = list(progress=progress)
     }
-    as.data.table(rbind(tempout))
+
+    outSED=foreach(i=1:length(subsnapIDs), .combine=.dumpout, .init=temp_file_output, .final=.dumpin, .inorder=FALSE, .options.snow = if(verbose){opts}, .packages=c('Viperfish','bigmemory'))%dopar%{
+      use=subsnapIDs[i]
+      mockloop=attach.big.matrix(mockpoint)
+      select=which(mockloop[,'subsnapID']==use)
+      snapshot=mockloop[select[1],'snapshot']
+      subvolume=mockloop[select[1],'subvolume']
+      id_galaxy_sky=mockloop[select,'id_galaxy_sky']
+      id_galaxy_sam=mockloop[select,'id_galaxy_sam']
+      zcos=mockloop[select,'zcos']
+      zobs=mockloop[select,'zobs']
+      SFHsing_subsnap=getSFHsing(id_galaxy_sam=id_galaxy_sam, snapshot=snapshot, subvolume=subvolume, path_shark=path_shark)
+
+      SFRbulge_d_subsnap=SFHsing_subsnap$SFRbulge_d
+      SFRbulge_m_subsnap=SFHsing_subsnap$SFRbulge_m
+      SFRdisk_subsnap=SFHsing_subsnap$SFRdisk
+      Zbulge_d_subsnap=SFHsing_subsnap$Zbulge_d
+      Zbulge_m_subsnap=SFHsing_subsnap$Zbulge_m
+      Zdisk_subsnap=SFHsing_subsnap$Zdisk
+
+      # Here we divide by h since the simulations output SFR in their native Msun/yr/h units.
+      tempout=foreach(j=1:length(select), .combine='rbind')%do%{
+        tempSED=tryCatch(c(id_galaxy_sky[SFHsing_subsnap$keep[j]], unlist(genSED(SFRbulge_d=SFRbulge_d_subsnap[j,]/h, SFRbulge_m=SFRbulge_m_subsnap[j,]/h, SFRdisk=SFRdisk_subsnap[j,]/h, redshift=zobs[j], time=time[1:dim(SFRdisk_subsnap)[2]]-cosdistTravelTime(zcos[j], ref='planck')*1e9, speclib=BC03lr, Zbulge_d=Zbulge_d_subsnap[j,], Zbulge_m=Zbulge_m_subsnap[j,], Zdisk=Zdisk_subsnap[j,], filtout=filtout, Dale=Dale_Msol, sparse=sparse, tau_birth=tau_birth, tau_screen=tau_screen, intSFR = intSFR))), error = function(e) NULL)
+        tempSED
+      }
+      as.data.table(rbind(tempout))
+    }
+
+    if(verbose){
+      close(pb)
+    }
+
+    stopCluster(cl)
   }
 
-  stopCluster(cl)
 
   #if(file.exists(temp_file_output)){
   #  assertAccess(temp_file_output, access='w')
   #  file.remove(temp_file_output)
   #}
-
-  if(verbose){
-    close(pb)
-  }
 
   outSED=as.data.frame(outSED)
   outSED=unique(outSED, by=id_galaxy_sky)

--- a/R/genSting.R
+++ b/R/genSting.R
@@ -171,6 +171,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
     close(pb)
   }
 
+  outSED=as.data.frame(outSED)
   outSED=unique(outSED, by=id_galaxy_sky)
 
   outSED=outSED[match(Sting_id_galaxy_sky, outSED$id_galaxy_sky),]

--- a/R/genSting.R
+++ b/R/genSting.R
@@ -173,8 +173,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
 
   outSED=as.data.frame(outSED)
   outSED=unique(outSED, by=id_galaxy_sky)
-
-  outSED=outSED[match(Sting_id_galaxy_sky, outSED$id_galaxy_sky),]
+  outSED=outSED[match(Sting_id_galaxy_sky, outSED[,1]),]
 
   if (write_final_file) {
     write.SED(outSED, filters, dirname(file_sting), final_file_output)

--- a/R/write.dataset.R
+++ b/R/write.dataset.R
@@ -160,7 +160,7 @@ write.SED = function(SED, filters, outdir, fname, verbose=FALSE)
     write.SED.hdf5(SED, fname, overwrite=TRUE, filters=filters)
   }
   else if (format == 'csv') {
-    write.SED.csv(outSED, filters, fname)
+    write.SED.csv(SED, filters, fname)
   }
 }
 

--- a/R/write.dataset.R
+++ b/R/write.dataset.R
@@ -92,21 +92,29 @@ write.SED.hdf5=function(SED, filename='temp.hdf5', overwrite=FALSE, filters=c('F
   SED=as.matrix(SED)
   SED[!is.finite(SED)]=-999
 
-  write.custom.dataset(filename=filename, group="SED/ab_nodust", object=SED[,1+colrun], dataset.name='bulge', overwrite=overwrite)
-  write.custom.dataset(filename=filename, group="SED/ab_nodust", object=SED[,1+colrun+Ncol], dataset.name='disk', overwrite=overwrite)
-  write.custom.dataset(filename=filename, group="SED/ab_nodust", object=SED[,1+colrun+Ncol*2], dataset.name='total', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ab_nodust", object=SED[,1+colrun], dataset.name='bulge_d', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ab_nodust", object=SED[,1+colrun+Ncol], dataset.name='bulge_m', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ab_nodust", object=SED[,1+colrun+Ncol*2], dataset.name='bulge_t', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ab_nodust", object=SED[,1+colrun+Ncol*3], dataset.name='disk', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ab_nodust", object=SED[,1+colrun+Ncol*4], dataset.name='total', overwrite=overwrite)
 
-  write.custom.dataset(filename=filename, group="SED/ap_nodust", object=SED[,1+colrun+Ncol*3], dataset.name='bulge', overwrite=overwrite)
-  write.custom.dataset(filename=filename, group="SED/ap_nodust", object=SED[,1+colrun+Ncol*4], dataset.name='disk', overwrite=overwrite)
-  write.custom.dataset(filename=filename, group="SED/ap_nodust", object=SED[,1+colrun+Ncol*5], dataset.name='total', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ap_nodust", object=SED[,1+colrun+Ncol*5], dataset.name='bulge_d', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ap_nodust", object=SED[,1+colrun+Ncol*6], dataset.name='bulge_m', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ap_nodust", object=SED[,1+colrun+Ncol*7], dataset.name='bulge_t', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ap_nodust", object=SED[,1+colrun+Ncol*8], dataset.name='disk', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ap_nodust", object=SED[,1+colrun+Ncol*9], dataset.name='total', overwrite=overwrite)
 
-  write.custom.dataset(filename=filename, group="SED/ab_dust", object=SED[,1+colrun+Ncol*6], dataset.name='bulge', overwrite=overwrite)
-  write.custom.dataset(filename=filename, group="SED/ab_dust", object=SED[,1+colrun+Ncol*7], dataset.name='disk', overwrite=overwrite)
-  write.custom.dataset(filename=filename, group="SED/ab_dust", object=SED[,1+colrun+Ncol*8], dataset.name='total', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ab_dust", object=SED[,1+colrun+Ncol*10], dataset.name='bulge_d', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ab_dust", object=SED[,1+colrun+Ncol*11], dataset.name='bulge_m', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ab_dust", object=SED[,1+colrun+Ncol*12], dataset.name='bulge_t', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ab_dust", object=SED[,1+colrun+Ncol*13], dataset.name='disk', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ab_dust", object=SED[,1+colrun+Ncol*14], dataset.name='total', overwrite=overwrite)
 
-  write.custom.dataset(filename=filename, group="SED/ap_dust", object=SED[,1+colrun+Ncol*9], dataset.name='bulge', overwrite=overwrite)
-  write.custom.dataset(filename=filename, group="SED/ap_dust", object=SED[,1+colrun+Ncol*10], dataset.name='disk', overwrite=overwrite)
-  write.custom.dataset(filename=filename, group="SED/ap_dust", object=SED[,1+colrun+Ncol*11], dataset.name='total', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ap_dust", object=SED[,1+colrun+Ncol*15], dataset.name='bulge_d', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ap_dust", object=SED[,1+colrun+Ncol*16], dataset.name='bulge_m', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ap_dust", object=SED[,1+colrun+Ncol*17], dataset.name='bulge_t', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ap_dust", object=SED[,1+colrun+Ncol*18], dataset.name='disk', overwrite=overwrite)
+  write.custom.dataset(filename=filename, group="SED/ap_dust", object=SED[,1+colrun+Ncol*19], dataset.name='total', overwrite=overwrite)
 }
 
 write.SED.csv = function(SED, filters, fname)


### PR DESCRIPTION
While testing the new HDF5 writing mechanism in Viperfish we found a few small issues that we're fixing with this pull request:

 * The data type conversion of the SED object before being handed over to the writing (i.e., the calls to `as.data.table` and `as.data.frame`) had been accidentally removed, they're back now; also a wrong variable name was preventing the CSV output from being generated.
 * Changed the structure of the HDF5 file in terms of which columns of the SED object map to which dataset names.
 * Since column names are assigned to SED objects *only* when CSV output is specified (and not in general), the matching operation happening in `genSting` was producing empty datasets since it was based on a column name of the SED object.
 * When a `restart=TRUE` execution is instructed, and the temporary file already contains all the necessary data, the `foreach` loop and its required infrastructure (cluster, progress bar, etc) are not required. As currently implemented they were actually failing to start, so we are fixing the situation, at least for the `genSting` function.