### PR TITLE
Extinction values from shark + 64bit int IDs

### DIFF
--- a/R/genSED.R
+++ b/R/genSED.R
@@ -1,4 +1,4 @@
-genSED=function(SFRbulge_d, SFRbulge_m, SFRdisk, redshift=0.1, time=NULL, tau_birth=1, tau_screen=0.3, Zbulge_d=5, Zbulge_m=5, Zdisk=5, alpha_SF=1, AGNfrac=0, ab_nodust=TRUE, ap_nodust=TRUE, ab_dust=TRUE, ap_dust=TRUE, emitdust=TRUE, unimax=13.8e9, speclib=NULL, Dale=NULL, filtout=NULL, H0=67.8, sparse=1, intSFR=TRUE){
+genSED=function(SFRbulge_d, SFRbulge_m, SFRdisk, redshift=0.1, time=NULL, tau_birth=1, tau_screen=0.3, pow_birth=-0.7, pow_screen=-0.7, Zbulge_d=5, Zbulge_m=5, Zdisk=5, alpha_SF=1, AGNfrac=0, ab_nodust=TRUE, ap_nodust=TRUE, ab_dust=TRUE, ap_dust=TRUE, emitdust=TRUE, unimax=13.8e9, speclib=NULL, Dale=NULL, filtout=NULL, H0=67.8, sparse=1, intSFR=TRUE){
 
   if(is.null(time)){stop('Need time input!')}
   if(is.null(speclib)){stop('Need speclib (e.g. BC03lr)')}
@@ -16,6 +16,9 @@ genSED=function(SFRbulge_d, SFRbulge_m, SFRdisk, redshift=0.1, time=NULL, tau_bi
 
   if(length(tau_birth)==1){tau_birth=rep(tau_birth,3)}
   if(length(tau_screen)==1){tau_screen=rep(tau_screen,3)}
+  if(length(pow_birth)==1){pow_birth=rep(pow_birth,3)}
+  if(length(pow_screen)==1){pow_screen=rep(pow_screen,3)}
+
   if(length(alpha_SF)==1){alpha_SF=rep(alpha_SF,3)}
   if(length(AGNfrac)==1){AGNfrac=rep(AGNfrac,3)}
 
@@ -26,6 +29,8 @@ genSED=function(SFRbulge_d, SFRbulge_m, SFRdisk, redshift=0.1, time=NULL, tau_bi
   assertNumeric(time)
   assertNumeric(tau_birth, len=3)
   assertNumeric(tau_screen, len=3)
+  assertNumeric(pow_birth, len=3)
+  assertNumeric(pow_screen, len=3)
   assertNumeric(Zbulge_d)
   assertNumeric(Zbulge_m)
   assertNumeric(Zdisk)
@@ -78,23 +83,23 @@ genSED=function(SFRbulge_d, SFRbulge_m, SFRdisk, redshift=0.1, time=NULL, tau_bi
   lumwave=speclib$Wave
 
   if(ap_nodust){
-    bulge_d_nodust=SFHfunc(SFRbulge_dfunc, tau_birth=0, tau_screen=0, speclib=speclib, z=redshift, Z=Z[[1]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
-    bulge_m_nodust=SFHfunc(SFRbulge_mfunc, tau_birth=0, tau_screen=0, speclib=speclib, z=redshift, Z=Z[[2]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
-    disk_nodust=SFHfunc(SFRdiskfunc, tau_birth=0, tau_screen=0, speclib=speclib, z=redshift, Z=Z[[3]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
+    bulge_d_nodust=SFHfunc(SFRbulge_dfunc, tau_birth=0, tau_screen=0, pow_birth=pow_birth[1], pow_screen=pow_screen[1], speclib=speclib, z=redshift, Z=Z[[1]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
+    bulge_m_nodust=SFHfunc(SFRbulge_mfunc, tau_birth=0, tau_screen=0, pow_birth=pow_birth[2], pow_screen=pow_screen[2], speclib=speclib, z=redshift, Z=Z[[2]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
+    disk_nodust=SFHfunc(SFRdiskfunc, tau_birth=0, tau_screen=0, pow_birth=pow_birth[3], pow_screen=pow_screen[3], speclib=speclib, z=redshift, Z=Z[[3]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
   }else if(ab_nodust | emitdust){
-    bulge_d_nodust=SFHfunc(SFRbulge_dfunc, tau_birth=0, tau_screen=0, speclib=speclib, z=0, Z=Z[[1]], outtype=NULL, intSFR=intSFR, sparse=sparse)
-    bulge_m_nodust=SFHfunc(SFRbulge_mfunc, tau_birth=0, tau_screen=0, speclib=speclib, z=0, Z=Z[[2]], outtype=NULL, intSFR=intSFR, sparse=sparse)
-    disk_nodust=SFHfunc(SFRdiskfunc, tau_birth=0, tau_screen=0, speclib=speclib, z=0, Z=Z[[3]], outtype=NULL, intSFR=intSFR, sparse=sparse)
+    bulge_d_nodust=SFHfunc(SFRbulge_dfunc, tau_birth=0, tau_screen=0, pow_birth=pow_birth[1], pow_screen=pow_screen[1], speclib=speclib, z=0, Z=Z[[1]], outtype=NULL, intSFR=intSFR, sparse=sparse)
+    bulge_m_nodust=SFHfunc(SFRbulge_mfunc, tau_birth=0, tau_screen=0, pow_birth=pow_birth[2], pow_screen=pow_screen[2], speclib=speclib, z=0, Z=Z[[2]], outtype=NULL, intSFR=intSFR, sparse=sparse)
+    disk_nodust=SFHfunc(SFRdiskfunc, tau_birth=0, tau_screen=0, pow_birth=pow_birth[3], pow_screen=pow_screen[3],speclib=speclib, z=0, Z=Z[[3]], outtype=NULL, intSFR=intSFR, sparse=sparse)
   }
 
   if(ap_dust){
-    bulge_d_dust=SFHfunc(SFRbulge_dfunc, tau_birth=tau_birth[1], tau_screen=tau_screen[1], speclib=speclib, z=redshift, Z=Z[[1]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
-    bulge_m_dust=SFHfunc(SFRbulge_mfunc, tau_birth=tau_birth[2], tau_screen=tau_screen[2], speclib=speclib, z=redshift, Z=Z[[2]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
-    disk_dust=SFHfunc(SFRdiskfunc, tau_birth=tau_birth[3], tau_screen=tau_screen[3], speclib=speclib, z=redshift, Z=Z[[3]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
+    bulge_d_dust=SFHfunc(SFRbulge_dfunc, tau_birth=tau_birth[1], tau_screen=tau_screen[1], pow_birth=pow_birth[1], pow_screen=pow_screen[1], speclib=speclib, z=redshift, Z=Z[[1]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
+    bulge_m_dust=SFHfunc(SFRbulge_mfunc, tau_birth=tau_birth[2], tau_screen=tau_screen[2], pow_birth=pow_birth[2], pow_screen=pow_screen[2], speclib=speclib, z=redshift, Z=Z[[2]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
+    disk_dust=SFHfunc(SFRdiskfunc, tau_birth=tau_birth[3], tau_screen=tau_screen[3], pow_birth=pow_birth[3], pow_screen=pow_screen[3], speclib=speclib, z=redshift, Z=Z[[3]], outtype=NULL, unimax=unimax, intSFR=intSFR, sparse=sparse)
   }else if(ab_dust){
-    bulge_d_dust=SFHfunc(SFRbulge_dfunc, tau_birth=tau_birth[1], tau_screen=tau_screen[1], speclib=speclib, z=0, Z=Z[[1]], outtype=NULL, intSFR=intSFR, sparse=sparse)
-    bulge_m_dust=SFHfunc(SFRbulge_mfunc, tau_birth=tau_birth[2], tau_screen=tau_screen[2], speclib=speclib, z=0, Z=Z[[2]], outtype=NULL, intSFR=intSFR, sparse=sparse)
-    disk_dust=SFHfunc(SFRdiskfunc, tau_birth=tau_birth[3], tau_screen=tau_screen[3], speclib=speclib, z=0, Z=Z[[3]], outtype=NULL, intSFR=intSFR, sparse=sparse)
+    bulge_d_dust=SFHfunc(SFRbulge_dfunc, tau_birth=tau_birth[1], tau_screen=tau_screen[1], pow_birth=pow_birth[1], pow_screen=pow_screen[1], speclib=speclib, z=0, Z=Z[[1]], outtype=NULL, intSFR=intSFR, sparse=sparse)
+    bulge_m_dust=SFHfunc(SFRbulge_mfunc, tau_birth=tau_birth[2], tau_screen=tau_screen[2], pow_birth=pow_birth[2], pow_screen=pow_screen[2], speclib=speclib, z=0, Z=Z[[2]], outtype=NULL, intSFR=intSFR, sparse=sparse)
+    disk_dust=SFHfunc(SFRdiskfunc, tau_birth=tau_birth[3], tau_screen=tau_screen[3], pow_birth=pow_birth[3], pow_screen=pow_screen[3], speclib=speclib, z=0, Z=Z[[3]], outtype=NULL, intSFR=intSFR, sparse=sparse)
   }
 
   if((ab_dust | ap_dust) & emitdust & !is.null(Dale)){

--- a/R/genShark.R
+++ b/R/genShark.R
@@ -1,4 +1,4 @@
-genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get", h='get', cores=4, id_galaxy_sam='all', filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, pow_birth=-0.7, pow_screen=-0.7, read_extinct=FALSE, sparse=5, final_file_output='Shark-SED.csv', intSFR=TRUE, verbose=TRUE, write_final_file=FALSE){
+genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get", h='get', cores=4, id_galaxy_sam='all', filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, pow_birth=-0.7, pow_screen=-0.7, read_extinct=FALSE, sparse=5, final_file_output='Shark-SED.csv', extinction_file='extinction.hdf5', intSFR=TRUE, verbose=TRUE, write_final_file=FALSE){
 
   timestart=proc.time()[3]
 
@@ -41,7 +41,7 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   Shark_SFH=h5file(sfh_fname, mode='r')
 
   if(read_extinct){
-      extinct_fname = paste(path_shark, snapshot, subvolume, 'extinction.hdf5',sep='/')
+      extinct_fname = paste(path_shark, snapshot, subvolume, extinction_file,sep='/')
       assertAccess(extinct_fname, access='r')
       Shark_Extinct=h5file(extinct_fname, mode='r')
   }
@@ -79,6 +79,7 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   tau_clump = matrix(ncol = 3, nrow = length(select)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
 
   pow_dust = matrix(ncol = 3, nrow = length(select)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
+  pow_clump = matrix(ncol = 3, nrow = length(select)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
 
   if(read_extinct){
      #read in disks

--- a/R/genShark.R
+++ b/R/genShark.R
@@ -1,4 +1,4 @@
-genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get", h='get', cores=4, id_galaxy_sam='all', filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, sparse=5, final_file_output='Shark-SED.csv', intSFR=TRUE, verbose=TRUE, write_final_file=FALSE){
+genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get", h='get', cores=4, id_galaxy_sam='all', filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, read_extinct=FALSE, sparse=5, final_file_output='Shark-SED.csv', intSFR=TRUE, verbose=TRUE, write_final_file=FALSE){
 
   timestart=proc.time()[3]
 
@@ -40,6 +40,11 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   assertAccess(sfh_fname, access='r')
   Shark_SFH=h5file(sfh_fname, mode='r')
 
+  
+  extinct_fname = paste(path_shark, snapshot, subvolume, 'extinction.hdf5',sep='/')
+  assertAccess(extinct_fname, access='r')
+  Shark_Extinct=h5file(extinct_fname, mode='r')
+
   # Read things in from the Shark HDF5 file:
 
   time=Shark_SFH[['lbt_mean']][]*1e9
@@ -69,6 +74,28 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   Zbulge_m=Shark_SFH[['bulges_mergers/metallicity_histories']][,select,drop=FALSE]
   Zdisk=Shark_SFH[['disks/metallicity_histories']][,select,drop=FALSE]
 
+  #define tau in extinction laws
+  tau_dust = matrix(ncol = 3, nrow = length(SFRbulge_d)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
+  tau_clump = matrix(ncol = 3, nrow = length(SFRbulge_d)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
+ 
+  if(read_extinct){
+     #read in disks
+     tau_dust[,3] = Shark_Extinct[['galaxies/tau_diff_disk']][,select,drop=FALSE]
+     tau_clump[,3] = Shark_Extinct[['galaxies/tau_clump_disk']][,select,drop=FALSE]
+
+     tau_dust[,1] = Shark_Extinct[['galaxies/tau_diff_bulge']][,select,drop=FALSE]
+     #bulges are a single phase
+     tau_clump[,1] = tau_dust[,1]
+
+     #assume the same for bulges regardless of origin of star formation
+     tau_dust[,2] = tau_dust[,1]
+     tau_clump[,2] = tau_clump[,1]
+  }
+  else{
+    tau_dust[,] = tau_screen
+    tau_clump[,] = tau_birth
+  }
+
   if(length(redshift)==1){
     redshift=rep(redshift, length(select))
   }
@@ -91,7 +118,7 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   # Here we divide by h since the simulations output SFR in their native Msun/yr/h units.
 
   outSED=foreach(i=1:iterations, .combine='rbind', .options.snow = if(verbose){opts})%dopar%{
-  unlist(genSED(SFRbulge_d=SFRbulge_d[,i]/h, SFRbulge_m=SFRbulge_m[,i]/h, SFRdisk=SFRdisk[,i]/h, redshift=redshift[i], time=time, speclib=BC03lr, Zbulge_d=Zbulge_d[,i], Zbulge_m=Zbulge_m[,i], Zdisk=Zdisk[,i], filtout=filtout, Dale=Dale_Msol, tau_birth=tau_birth, tau_screen=tau_screen, sparse=sparse, intSFR=intSFR))
+  unlist(genSED(SFRbulge_d=SFRbulge_d[,i]/h, SFRbulge_m=SFRbulge_m[,i]/h, SFRdisk=SFRdisk[,i]/h, redshift=redshift[i], time=time, speclib=BC03lr, Zbulge_d=Zbulge_d[,i], Zbulge_m=Zbulge_m[,i], Zdisk=Zdisk[,i], filtout=filtout, Dale=Dale_Msol, tau_birth=tau_clump[,i], tau_screen=tau_dust[,i], sparse=sparse, intSFR=intSFR))
   }
 
   stopCluster(cl)

--- a/R/genShark.R
+++ b/R/genShark.R
@@ -75,21 +75,22 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   Zdisk=Shark_SFH[['disks/metallicity_histories']][,select,drop=FALSE]
 
   #define tau in extinction laws
-  tau_dust = matrix(ncol = 3, nrow = length(SFRbulge_d)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
-  tau_clump = matrix(ncol = 3, nrow = length(SFRbulge_d)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
- 
+  tau_dust = matrix(ncol = 3, nrow = length(select)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
+  tau_clump = matrix(ncol = 3, nrow = length(select)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
+
+  print("will now read extinction") 
   if(read_extinct){
      #read in disks
-     tau_dust[,3] = Shark_Extinct[['galaxies/tau_diff_disk']][,select,drop=FALSE]
-     tau_clump[,3] = Shark_Extinct[['galaxies/tau_clump_disk']][,select,drop=FALSE]
+     tau_dust[3,] = Shark_Extinct[['galaxies/tau_diff_disk']][,select,drop=FALSE]
+     tau_clump[3,] = Shark_Extinct[['galaxies/tau_clump_disk']][,select,drop=FALSE]
 
-     tau_dust[,1] = Shark_Extinct[['galaxies/tau_diff_bulge']][,select,drop=FALSE]
+     tau_dust[1,] = Shark_Extinct[['galaxies/tau_diff_bulge']][,select,drop=FALSE]
      #bulges are a single phase
-     tau_clump[,1] = tau_dust[,1]
+     tau_clump[1,] = tau_dust[1,]
 
      #assume the same for bulges regardless of origin of star formation
-     tau_dust[,2] = tau_dust[,1]
-     tau_clump[,2] = tau_clump[,1]
+     tau_dust[2,] = tau_dust[1,]
+     tau_clump[2,] = tau_clump[1,]
   }
   else{
     tau_dust[,] = tau_screen
@@ -118,7 +119,7 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   # Here we divide by h since the simulations output SFR in their native Msun/yr/h units.
 
   outSED=foreach(i=1:iterations, .combine='rbind', .options.snow = if(verbose){opts})%dopar%{
-  unlist(genSED(SFRbulge_d=SFRbulge_d[,i]/h, SFRbulge_m=SFRbulge_m[,i]/h, SFRdisk=SFRdisk[,i]/h, redshift=redshift[i], time=time, speclib=BC03lr, Zbulge_d=Zbulge_d[,i], Zbulge_m=Zbulge_m[,i], Zdisk=Zdisk[,i], filtout=filtout, Dale=Dale_Msol, tau_birth=tau_clump[,i], tau_screen=tau_dust[,i], sparse=sparse, intSFR=intSFR))
+  unlist(genSED(SFRbulge_d=SFRbulge_d[,i]/h, SFRbulge_m=SFRbulge_m[,i]/h, SFRdisk=SFRdisk[,i]/h, redshift=redshift[i], time=time, speclib=BC03lr, Zbulge_d=Zbulge_d[,i], Zbulge_m=Zbulge_m[,i], Zdisk=Zdisk[,i], filtout=filtout, Dale=Dale_Msol, tau_birth=tau_clump[i,], tau_screen=tau_dust[i,], sparse=sparse, intSFR=intSFR))
   }
 
   stopCluster(cl)

--- a/R/genShark.R
+++ b/R/genShark.R
@@ -1,4 +1,4 @@
-genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get", h='get', cores=4, id_galaxy_sam='all', filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, read_extinct=FALSE, sparse=5, final_file_output='Shark-SED.csv', intSFR=TRUE, verbose=TRUE, write_final_file=FALSE){
+genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get", h='get', cores=4, id_galaxy_sam='all', filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, pow_birth=-0.7, pow_screen=-0.7, read_extinct=FALSE, sparse=5, final_file_output='Shark-SED.csv', intSFR=TRUE, verbose=TRUE, write_final_file=FALSE){
 
   timestart=proc.time()[3]
 
@@ -40,13 +40,13 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   assertAccess(sfh_fname, access='r')
   Shark_SFH=h5file(sfh_fname, mode='r')
 
-  
-  extinct_fname = paste(path_shark, snapshot, subvolume, 'extinction.hdf5',sep='/')
-  assertAccess(extinct_fname, access='r')
-  Shark_Extinct=h5file(extinct_fname, mode='r')
+  if(read_extinct){
+      extinct_fname = paste(path_shark, snapshot, subvolume, 'extinction.hdf5',sep='/')
+      assertAccess(extinct_fname, access='r')
+      Shark_Extinct=h5file(extinct_fname, mode='r')
+  }
 
   # Read things in from the Shark HDF5 file:
-
   time=Shark_SFH[['lbt_mean']][]*1e9
 
   if(redshift[1]=='get'){
@@ -78,22 +78,31 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   tau_dust = matrix(ncol = 3, nrow = length(select)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
   tau_clump = matrix(ncol = 3, nrow = length(select)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
 
+  pow_dust = matrix(ncol = 3, nrow = length(select)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
+
   if(read_extinct){
      #read in disks
      tau_dust[,3] = Shark_Extinct[['galaxies/tau_diff_disk']][select]
      tau_clump[,3] = Shark_Extinct[['galaxies/tau_clump_disk']][select]
+     pow_dust[,3] = Shark_Extinct[['galaxies/m_diff_disk']][select]
 
      tau_dust[,1] = Shark_Extinct[['galaxies/tau_diff_bulge']][select]
-     #bulges are a single phase
-     tau_clump[,1] = tau_dust[,1]
+     tau_clump[,1] = Shark_Extinct[['galaxies/tau_clump_bulge']][select]
+     pow_dust[,1] = Shark_Extinct[['galaxies/m_diff_bulge']][select]
 
      #assume the same for bulges regardless of origin of star formation
      tau_dust[,2] = tau_dust[,1]
      tau_clump[,2] = tau_clump[,1]
+     pow_dust[,2] = pow_dust[,1]
+ 
+     #all clumps have the same power law index of the Charlot & Fall model
+     pow_clump[,] = pow_birth
   }
   else{
     tau_dust[,] = tau_screen
     tau_clump[,] = tau_birth
+    pow_dust[,] = pow_screen
+    pow_clump[,] = pow_birth
   }
 
   if(length(redshift)==1){
@@ -118,7 +127,7 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   # Here we divide by h since the simulations output SFR in their native Msun/yr/h units.
 
   outSED=foreach(i=1:iterations, .combine='rbind', .options.snow = if(verbose){opts})%dopar%{
-  unlist(genSED(SFRbulge_d=SFRbulge_d[,i]/h, SFRbulge_m=SFRbulge_m[,i]/h, SFRdisk=SFRdisk[,i]/h, redshift=redshift[i], time=time, speclib=BC03lr, Zbulge_d=Zbulge_d[,i], Zbulge_m=Zbulge_m[,i], Zdisk=Zdisk[,i], filtout=filtout, Dale=Dale_Msol, tau_birth=tau_clump[i,], tau_screen=tau_dust[i,], sparse=sparse, intSFR=intSFR))
+  unlist(genSED(SFRbulge_d=SFRbulge_d[,i]/h, SFRbulge_m=SFRbulge_m[,i]/h, SFRdisk=SFRdisk[,i]/h, redshift=redshift[i], time=time, speclib=BC03lr, Zbulge_d=Zbulge_d[,i], Zbulge_m=Zbulge_m[,i], Zdisk=Zdisk[,i], filtout=filtout, Dale=Dale_Msol, tau_birth=tau_clump[i,], tau_screen=tau_dust[i,], pow_birth=pow_clump[i,], pow_screen=pow_clump[i,], sparse=sparse, intSFR=intSFR))
   }
 
   stopCluster(cl)

--- a/R/genShark.R
+++ b/R/genShark.R
@@ -78,19 +78,18 @@ genShark=function(path_shark='.', snapshot=NULL, subvolume=NULL, redshift="get",
   tau_dust = matrix(ncol = 3, nrow = length(select)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
   tau_clump = matrix(ncol = 3, nrow = length(select)) #this is ordered as bulge (disk-ins), bulge (mergers), disks
 
-  print("will now read extinction") 
   if(read_extinct){
      #read in disks
-     tau_dust[3,] = Shark_Extinct[['galaxies/tau_diff_disk']][,select,drop=FALSE]
-     tau_clump[3,] = Shark_Extinct[['galaxies/tau_clump_disk']][,select,drop=FALSE]
+     tau_dust[,3] = Shark_Extinct[['galaxies/tau_diff_disk']][select]
+     tau_clump[,3] = Shark_Extinct[['galaxies/tau_clump_disk']][select]
 
-     tau_dust[1,] = Shark_Extinct[['galaxies/tau_diff_bulge']][,select,drop=FALSE]
+     tau_dust[,1] = Shark_Extinct[['galaxies/tau_diff_bulge']][select]
      #bulges are a single phase
-     tau_clump[1,] = tau_dust[1,]
+     tau_clump[,1] = tau_dust[,1]
 
      #assume the same for bulges regardless of origin of star formation
-     tau_dust[2,] = tau_dust[1,]
-     tau_clump[2,] = tau_clump[1,]
+     tau_dust[,2] = tau_dust[,1]
+     tau_clump[,2] = tau_clump[,1]
   }
   else{
     tau_dust[,] = tau_screen

--- a/R/genSting.R
+++ b/R/genSting.R
@@ -176,7 +176,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
   #}
 
   outSED=as.data.frame(outSED)
-  outSED=unique(outSED, by=id_galaxy_sky)
+  outSED=unique(outSED, by=1)
   outSED=outSED[match(Sting_id_galaxy_sky, outSED[,1]),]
 
   if (write_final_file) {

--- a/R/genSting.R
+++ b/R/genSting.R
@@ -1,3 +1,14 @@
+with_64bit_ints = function(x)
+{
+    # When reading 64 bit integers let's make sure hdf5r reads them as such;
+    # otherwise the default behavior is convert to int32 or double if they don't loose precision
+    old_option = getOption('hdf5r.h5tor_default')
+    options(hdf5r.h5tor_default = h5const$H5TOR_CONV_NONE)
+    result = x
+    options(hdf5r.h5tor_default = old_option)
+    invisible(result)
+}
+
 genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199, filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, sparse=5, time=NULL, mockcone=NULL, intSFR=TRUE, final_file_output='Stingray-SED.csv', temp_file_output='temp.csv', reorder=TRUE, restart=FALSE, verbose=TRUE, write_final_file=FALSE){
 
   timestart=proc.time()[3]
@@ -45,7 +56,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
     rm(Shark_date)
 
     #Extract the original id_galaxy_sky for final re-ordering.
-    Sting_id_galaxy_sky=h5file(file_sting, mode='r')[['galaxies/id_galaxy_sky']][]
+    Sting_id_galaxy_sky = with_64bit_ints(h5file(file_sting, mode='r')[['galaxies/id_galaxy_sky']][])
   }else{
     if(! is.null(mockcone)){
       Sting_id_galaxy_sky=mockcone$id_galaxy_sky
@@ -95,7 +106,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
   #Make mock subsets:
 
   if(is.null(mockcone)){
-    mockcone=mockcone_extract(file_sting=file_sting, reorder=reorder)
+    mockcone = with_64bit_ints(mockcone_extract(file_sting=file_sting, reorder=reorder))
   }else{
     assertDataTable(mockcone)
   }

--- a/R/genSting.R
+++ b/R/genSting.R
@@ -175,8 +175,8 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
   #  file.remove(temp_file_output)
   #}
 
-  outSED=as.data.frame(outSED)
   outSED=unique(outSED, by=1)
+  outSED=as.data.frame(outSED)
   outSED=outSED[match(Sting_id_galaxy_sky, outSED[,1]),]
 
   if (write_final_file) {

--- a/R/genSting.R
+++ b/R/genSting.R
@@ -65,6 +65,8 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
     }
   }
 
+  message(paste0('#Galaxy IDs from mock catalogue: ', length(Sting_id_galaxy_sky),
+                 ', type/class: ', typeof(Sting_id_galaxy_sky), '/', class(Sting_id_galaxy_sky)))
   assertScalar(h)
 
   BC03lr=Dale_Msol=Nid=id_galaxy_sky=id_galaxy_sam=idlist=snapshot=subsnapID=subvolume=z=i=j=Ntime=zobs=NULL


### PR DESCRIPTION
These changes should allow Viperfish to read extinction parameters from shark output instead of assuming default values (authored by Claudia).

I'm also including the changed we put some time ago to allow to correctly read 64bit ints out of the HDF5 files.