### PR TITLE
Hiding private functions

### DIFF
--- a/R/genSting.R
+++ b/R/genSting.R
@@ -1,4 +1,4 @@
-with_64bit_ints = function(x)
+.with_64bit_ints = function(x)
 {
     # When reading 64 bit integers let's make sure hdf5r reads them as such;
     # otherwise the default behavior is convert to int32 or double if they don't loose precision
@@ -56,7 +56,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
     rm(Shark_date)
 
     #Extract the original id_galaxy_sky for final re-ordering.
-    Sting_id_galaxy_sky = with_64bit_ints(h5file(file_sting, mode='r')[['galaxies/id_galaxy_sky']][])
+    Sting_id_galaxy_sky = .with_64bit_ints(h5file(file_sting, mode='r')[['galaxies/id_galaxy_sky']][])
   }else{
     if(! is.null(mockcone)){
       Sting_id_galaxy_sky=mockcone$id_galaxy_sky
@@ -108,7 +108,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
   #Make mock subsets:
 
   if(is.null(mockcone)){
-    mockcone = with_64bit_ints(mockcone_extract(file_sting=file_sting, reorder=reorder))
+    mockcone = .with_64bit_ints(mockcone_extract(file_sting=file_sting, reorder=reorder))
   }else{
     assertDataTable(mockcone)
   }

--- a/R/write.dataset.R
+++ b/R/write.dataset.R
@@ -61,7 +61,7 @@ write.custom.dataset = function(filename='temp.hdf5', # hd5 filename
   }
 }
 
-write.SED.hdf5=function(SED, filename='temp.hdf5', overwrite=FALSE, filters=c('FUV', 'NUV', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1', 'W2', 'W3', 'W4', 'P100', 'P160', 'S250', 'S350', 'S500')){
+.write.SED.hdf5=function(SED, filename='temp.hdf5', overwrite=FALSE, filters=c('FUV', 'NUV', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1', 'W2', 'W3', 'W4', 'P100', 'P160', 'S250', 'S350', 'S500')){
 
   assertPathForOutput(filename, overwrite=TRUE)
   file.h5=h5file(filename=filename, mode='a')
@@ -117,7 +117,7 @@ write.SED.hdf5=function(SED, filename='temp.hdf5', overwrite=FALSE, filters=c('F
   write.custom.dataset(filename=filename, group="SED/ap_dust", object=SED[,1+colrun+Ncol*19], dataset.name='total', overwrite=overwrite)
 }
 
-write.SED.csv = function(SED, filters, filename)
+.write.SED.csv = function(SED, filters, filename)
 {
   colnames = c(
       'id_galaxy',
@@ -165,10 +165,10 @@ write.SED = function(SED, filters, outdir, filename, verbose=FALSE)
   filename = paste(outdir, filename, sep='/')
   message(paste('Writing SED to', filename))
   if (format == 'hdf5') {
-    write.SED.hdf5(SED, filename, overwrite=TRUE, filters=filters)
+    .write.SED.hdf5(SED, filename, overwrite=TRUE, filters=filters)
   }
   else if (format == 'csv') {
-    write.SED.csv(SED, filters, filename)
+    .write.SED.csv(SED, filters, filename)
   }
 }
 


### PR DESCRIPTION
These functions are only meant to be used internally, so they don't
require to be exported through the Viperfish namespace, nor they need
further documentation.