### PR TITLE
Add support for multiple levels of parallelism in genSting()

### DIFF
--- a/R/genSting.R
+++ b/R/genSting.R
@@ -9,7 +9,7 @@
     invisible(result)
 }
 
-genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199, filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, pow_birth=-0.7, pow_screen=-0.7,  alpha_SF_birth=1, alpha_SF_screen=3, alpha_SF_AGN=0, read_extinct=FALSE, sparse=5, time=NULL, mockcone=NULL, intSFR=TRUE, final_file_output='Stingray-SED.csv', temp_file_output='temp.csv',  extinction_file='extinction.hdf5', reorder=TRUE, restart=FALSE, verbose=TRUE, write_final_file=FALSE){
+genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/dev/null", snapmax=199, filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, pow_birth=-0.7, pow_screen=-0.7,  alpha_SF_birth=1, alpha_SF_screen=3, alpha_SF_AGN=0, read_extinct=FALSE, sparse=5, time=NULL, mockcone=NULL, intSFR=TRUE, final_file_output='Stingray-SED.csv', temp_file_output='temp.csv',  extinction_file='extinction.hdf5', reorder=TRUE, restart=FALSE, verbose=TRUE, write_final_file=FALSE){
 
   timestart=proc.time()[3]
 
@@ -166,7 +166,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', cores=4, snapmax=199
 
   if (run_foreach) {
 
-    cl=makeCluster(cores)
+    cl=makeCluster(cores, outfile=children_outfile)
     registerDoSNOW(cl)
 
     if(verbose){

--- a/R/genSting.R
+++ b/R/genSting.R
@@ -176,6 +176,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/d
     }
 
     outSED=foreach(i=1:length(subsnapIDs), .combine=.dumpout, .init=temp_file_output, .final=.dumpin, .inorder=FALSE, .options.snow = if(verbose){opts}, .packages=c('Viperfish','bigmemory'))%dopar%{
+      cat(format(Sys.time(), "%X"), "Processing snapshot", i, "of", length(subsnapIDs), "\n")
       use=subsnapIDs[i]
       mockloop=attach.big.matrix(mockpoint)
       select=which(mockloop[,'subsnapID']==use)
@@ -185,7 +186,11 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/d
       id_galaxy_sam=mockloop[select,'id_galaxy_sam']
       zcos=mockloop[select,'zcos']
       zobs=mockloop[select,'zobs']
+      read_start = Sys.time()
+      cat(format(read_start, "%X"), "Reading SFH for snapshot", i, "\n")
       SFHsing_subsnap=getSFHsing(id_galaxy_sam=id_galaxy_sam, snapshot=snapshot, subvolume=subvolume, path_shark=path_shark)
+      read_end = Sys.time()
+      cat(format(read_end, "%X"), "Read SFH for snapshot", i, "in", as.numeric(read_end - read_start, units="secs"),"\n")
 
       SFRbulge_d_subsnap=SFHsing_subsnap$SFRbulge_d
       SFRbulge_m_subsnap=SFHsing_subsnap$SFRbulge_m
@@ -225,9 +230,11 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/d
         pow_screen_galaxies[,] = pow_screen
         pow_birth_galaxies[,] = pow_birth
       }
+
+      cat(format(Sys.time(), "%X"), "Going into inner loop with", length(select), "elements\n")
       # Here we divide by h since the simulations output SFR in their native Msun/yr/h units.
       tempout=foreach(j=1:length(select), .combine='rbind')%do%{
-        
+         cat(format(Sys.time(), "%X"), "Calculating SED for galaxy", j, "of", length(select), "in snapshot", i, "\n")
          tempSED=tryCatch(c(id_galaxy_sky[SFHsing_subsnap$keep[j]], 
             unlist(genSED(
 	      SFRbulge_d=SFRbulge_d_subsnap[j,]/h, 

--- a/R/genSting.R
+++ b/R/genSting.R
@@ -9,7 +9,7 @@
     invisible(result)
 }
 
-genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/dev/null", snapmax=199, filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, pow_birth=-0.7, pow_screen=-0.7,  alpha_SF_birth=1, alpha_SF_screen=3, alpha_SF_AGN=0, read_extinct=FALSE, sparse=5, time=NULL, mockcone=NULL, intSFR=TRUE, final_file_output='Stingray-SED.csv', temp_file_output='temp.csv',  extinction_file='extinction.hdf5', reorder=TRUE, restart=FALSE, verbose=TRUE, write_final_file=FALSE){
+genSting=function(file_sting=NULL, path_shark='.', h='get', cores_per_subvolume=1, cores_per_snapshot=4, children_outfile="/dev/null", snapmax=199, filters=c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'), tau_birth=1.5, tau_screen=0.5, pow_birth=-0.7, pow_screen=-0.7,  alpha_SF_birth=1, alpha_SF_screen=3, alpha_SF_AGN=0, read_extinct=FALSE, sparse=5, time=NULL, mockcone=NULL, intSFR=TRUE, final_file_output='Stingray-SED.csv', temp_file_output='temp.csv',  extinction_file='extinction.hdf5', reorder=TRUE, restart=FALSE, verbose=TRUE, write_final_file=FALSE){
 
   timestart=proc.time()[3]
 
@@ -19,7 +19,8 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/d
 
   assertCharacter(path_shark, max.len=1)
   assertAccess(path_shark, access='r')
-  assertInt(cores)
+  assertInt(cores_per_subvolume)
+  assertInt(cores_per_snapshot)
   assertInt(snapmax)
   if(is.list(filters)){
     filterlist=TRUE
@@ -101,7 +102,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/d
   # }
   #
   # if(is.null(SFHfull) & doSFHbatch==FALSE){
-  #   SFHfull=getSFHfull(file_sting=file_sting, path_shark=path_shark, snapmax=snapmax, cores=cores, verbose=verbose)
+  #   SFHfull=getSFHfull(file_sting=file_sting, path_shark=path_shark, snapmax=snapmax, cores_per_subvolume=cores_per_subvolume, verbose=verbose)
   # }
   #
   # if(!is.null(SFHfull)){
@@ -166,7 +167,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/d
 
   if (run_foreach) {
 
-    cl=makeCluster(cores, outfile=children_outfile)
+    cl=makeCluster(cores_per_subvolume, outfile=children_outfile)
     registerDoSNOW(cl)
 
     if(verbose){
@@ -175,7 +176,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/d
       opts = list(progress=progress)
     }
 
-    outSED=foreach(i=1:length(subsnapIDs), .combine=.dumpout, .init=temp_file_output, .final=.dumpin, .inorder=FALSE, .options.snow = if(verbose){opts}, .packages=c('Viperfish','bigmemory'))%dopar%{
+    outSED=foreach(i=1:length(subsnapIDs), .combine=.dumpout, .init=temp_file_output, .final=.dumpin, .inorder=FALSE, .options.snow = if(verbose){opts}, .packages=c('Viperfish','bigmemory','doSNOW'))%dopar%{
       cat(format(Sys.time(), "%X"), "Processing snapshot", i, "of", length(subsnapIDs), "\n")
       use=subsnapIDs[i]
       mockloop=attach.big.matrix(mockpoint)
@@ -231,9 +232,11 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/d
         pow_birth_galaxies[,] = pow_birth
       }
 
+      cl = makeCluster(cores_per_snapshot, outfile=children_outfile)
+      registerDoSNOW(cl)
       cat(format(Sys.time(), "%X"), "Going into inner loop with", length(select), "elements\n")
       # Here we divide by h since the simulations output SFR in their native Msun/yr/h units.
-      tempout=foreach(j=1:length(select), .combine='rbind')%do%{
+      tempout=foreach(j=1:length(select), .combine='rbind') %dopar% {
          cat(format(Sys.time(), "%X"), "Calculating SED for galaxy", j, "of", length(select), "in snapshot", i, "\n")
          tempSED=tryCatch(c(id_galaxy_sky[SFHsing_subsnap$keep[j]], 
             unlist(genSED(
@@ -263,6 +266,7 @@ genSting=function(file_sting=NULL, path_shark='.', h='get', children_outfile="/d
         #if(class(tempSED)=="try-error"){tempSED=NA}
         tempSED
       }
+      stopCluster(cl)
       as.data.table(rbind(tempout))
     }
 

--- a/R/getSFH.R
+++ b/R/getSFH.R
@@ -1,4 +1,4 @@
-getSFHfull=function(file_sting='mocksurvey.hdf5', path_shark='.', snapmax=199, cores=4, verbose=TRUE){
+getSFHfull=function(file_sting='mocksurvey.hdf5', path_shark='.', snapmax=199, cores_per_subvolume=4, verbose=TRUE){
 
   timestart=proc.time()[3]
 
@@ -11,7 +11,7 @@ getSFHfull=function(file_sting='mocksurvey.hdf5', path_shark='.', snapmax=199, c
   assertCharacter(path_shark, max.len=1)
   assertAccess(path_shark, access='r')
   assertInt(snapmax)
-  assertInt(cores)
+  assertInt(cores_per_subvolume)
   assertFlag(verbose)
 
   BC03lr=Dale_Msol=Nid=id_galaxy_sam=idlist=snapshot=subsnapID=subvolume=z=i=mocksubsets=mockcone=Ntime=time=NULL
@@ -36,7 +36,7 @@ getSFHfull=function(file_sting='mocksurvey.hdf5', path_shark='.', snapmax=199, c
   Zbulge_m=matrix(0,Nunique,Ntime)
   Zdisk=matrix(0,Nunique,Ntime)
 
-  cl=makeCluster(cores)
+  cl=makeCluster(cores_per_subvolume)
   registerDoSNOW(cl)
 
   Nstart=1

--- a/man/genSting.Rd
+++ b/man/genSting.Rd
@@ -13,9 +13,9 @@ Convert Stingray Outputs to SEDs
 Takes Stingray light cones and converts to apparent and absolute SEDs.
 }
 \usage{
-genSting(file_sting = NULL, path_shark = ".", h = 'get', cores = 4, snapmax = 199,
-filters = c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS', 'Z_VISTA',
-'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE',
+genSting(file_sting = NULL, path_shark = ".", h = 'get', cores = 4, children_outfile = '/dev/null',
+snapmax = 199, filters = c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS',
+'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE',
 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'),
 tau_birth = 1.5, tau_screen = 0.5, sparse = 5, time = NULL, mockcone = NULL,
 intSFR = TRUE, final_file_output = 'Stingray-SED.csv', temp_file_output = 'temp.csv',
@@ -49,6 +49,9 @@ Numeric scalar; little-h assumed in Shark (needed to convert SFRs to actual SFR 
 }
   \item{cores}{
 Integer scalar; number of cores to process on.
+}
+  \item{children_output}{
+Character scalar; file where parallel worker's outputs will be dumped to. It is given as-is to SNOW's \code{makeCluster}.
 }
   \item{snapmax}{
 Integer scalar; maximum snapshot output by Shark.

--- a/man/genSting.Rd
+++ b/man/genSting.Rd
@@ -13,16 +13,18 @@ Convert Stingray Outputs to SEDs
 Takes Stingray light cones and converts to apparent and absolute SEDs.
 }
 \usage{
-genSting(file_sting = NULL, path_shark = ".", h = 'get', cores = 4, children_outfile = '/dev/null',
-snapmax = 199, filters = c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS',
-'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE', 'W4_WISE',
-'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel', 'S500_Herschel'),
+genSting(file_sting = NULL, path_shark = ".", h = 'get', cores_per_subvolume=1,
+cores_per_snapshot=4, children_outfile = '/dev/null', snapmax = 199,
+filters = c('FUV_GALEX', 'NUV_GALEX', 'u_SDSS', 'g_SDSS', 'r_SDSS', 'i_SDSS',
+'Z_VISTA', 'Y_VISTA', 'J_VISTA', 'H_VISTA', 'K_VISTA', 'W1_WISE', 'W2_WISE', 'W3_WISE',
+'W4_WISE', 'P100_Herschel', 'P160_Herschel', 'S250_Herschel', 'S350_Herschel',
+'S500_Herschel'),
 tau_birth = 1.5, tau_screen = 0.5, sparse = 5, time = NULL, mockcone = NULL,
 intSFR = TRUE, final_file_output = 'Stingray-SED.csv', temp_file_output = 'temp.csv',
 reorder = TRUE, restart = FALSE, verbose = TRUE, write_final_file = FALSE)
 
-getSFHfull(file_sting = "mocksurvey.hdf5", path_shark = ".", snapmax = 199, cores = 4,
-verbose = TRUE)
+getSFHfull(file_sting = "mocksurvey.hdf5", path_shark = ".", snapmax = 199,
+cores_per_subvolume = 4, verbose = TRUE)
 
 getSFHsing(id_galaxy_sam, snapshot = NULL, subvolume = NULL, path_shark = ".")
 
@@ -47,8 +49,11 @@ Integer vector; a list of Shark SAM galaxies to be extracted from a given snapsh
   \item{h}{
 Numeric scalar; little-h assumed in Shark (needed to convert SFRs to actual SFR since they use Msun/yr/h). If set to "get" (default) it will inherit the redshift from the target Stingray HDF5 file, which is probably what you want most of the time.
 }
-  \item{cores}{
-Integer scalar; number of cores to process on.
+  \item{cores_per_subvolume}{
+Integer scalar; number of cores to process a subvolume's snapshot on. This multiplied by \code{cores_per_snapshot} yields the total number of processes that will work in parallel.
+}
+  \item{cores_per_snapshot}{
+Integer scalar; number of cores to process a snapshot's galaxies on. This multiplied by \code{cores_per_subvolume} yields the total number of processes that will work in parallel.
 }
   \item{children_output}{
 Character scalar; file where parallel worker's outputs will be dumped to. It is given as-is to SNOW's \code{makeCluster}.

--- a/man/genSting.Rd
+++ b/man/genSting.Rd
@@ -80,7 +80,7 @@ Numeric scalar; amount of sparse sampling of the spectra to make. Higher values 
 Boolean scalar; should the \option{massfunc} be intergrated between ages? This might be necessary if the SFH is quite bursty, but it is more expensive to compute and not required if the SFH is quite smooth.
 }
   \item{final_file_output}{
-Character scalar;  name for the final output file to write to. This should not be an existing file and end ".csv".
+Character scalar;  name for the final output file to write to. This should not be an existing file and end ".csv" or ".hdf5".
 }
   \item{temp_file_output}{
 Character scalar; name for the temporary file to write to. This should not be an existing file and end ".csv".


### PR DESCRIPTION
These changes include adding a new parallelisation level in genSting() in order to be able to finish snapshot processing faster, hence dumping results to disk with a higher cadence than otherwise possible until now.

The changes include also a few output messages, an option to see the messages written to stdout by the worker on the main process (or on files, etc), plus small documentation updates. Have a look at each commit individually if you want to see changes in isolation.